### PR TITLE
Add patch for LibreELEC (LE10)

### DIFF
--- a/LibreELEC/LibreELEC10-zlib-ng.patch
+++ b/LibreELEC/LibreELEC10-zlib-ng.patch
@@ -1,0 +1,28 @@
+diff --git a/packages/compress/zlib/package.mk b/packages/compress/zlib/package.mk
+index f39e64dee8..5dd78604a8 100644
+--- a/packages/compress/zlib/package.mk
++++ b/packages/compress/zlib/package.mk
+@@ -1,13 +1,18 @@
+ # SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
++# Copyright (C) 2021-present Team LibreELEC (https://libreelec.tv)
+ 
+ PKG_NAME="zlib"
+-PKG_VERSION="1.2.11"
+-PKG_SHA256="4ff941449631ace0d4d203e3483be9dbc9da454084111f97ea0a2114e19bf066"
++PKG_VERSION="2.0.2"
++PKG_SHA256="dd37886f22ca6890e403ea6c1d60f36eab1d08d2f232a35f5b02126621149d28"
+ PKG_LICENSE="OSS"
+-PKG_SITE="http://www.zlib.net"
+-PKG_URL="http://zlib.net/${PKG_NAME}-${PKG_VERSION}.tar.xz"
++PKG_SITE="https://github.com/zlib-ng/zlib-ng"
++PKG_URL="https://github.com/zlib-ng/zlib-ng/archive/refs/tags/${PKG_VERSION}.tar.gz"
+ PKG_DEPENDS_HOST="cmake:host"
+ PKG_DEPENDS_TARGET="toolchain"
+-PKG_LONGDESC="A general purpose (ZIP) data compression library."
++PKG_LONGDESC="zlib data compression library for the next generation systems"
+ PKG_TOOLCHAIN="cmake-make"
++
++PKG_CMAKE_OPTS_HOST="-DZLIB_COMPAT=ON"
++
++PKG_CMAKE_OPTS_TARGET="-DZLIB_COMPAT=ON"

--- a/LibreELEC/README.md
+++ b/LibreELEC/README.md
@@ -1,0 +1,4 @@
+## LibreELEC10-zlib-ng.patch
+* Patch created against LibreELEC (LE10)
+* Link full distro against zlib-ng instead of zlib
+* Apply patch against https://github.com/LibreELEC/LibreELEC.tv


### PR DESCRIPTION
Has been tested on x86_64 (Intel TGL) and aarch64 (Odroid N2+ S922X) as a full distro replacement.