### PR TITLE
Add patch for nginx 1.25.3

### DIFF
--- a/nginx/1.25.3-zlib-ng.patch
+++ b/nginx/1.25.3-zlib-ng.patch
@@ -1,6 +1,6 @@
 diff -urN nginx-1.25.3.orig/auto/lib/zlib/conf nginx-1.25.3/auto/lib/zlib/conf
 --- nginx-1.25.3.orig/auto/lib/zlib/conf	2023-10-24 15:46:47.000000000 +0200
-+++ nginx-1.25.3/auto/lib/zlib/conf	2023-11-25 04:00:16.017729654 +0100
++++ nginx-1.25.3/auto/lib/zlib/conf	2023-11-25 16:50:20.103591053 +0100
 @@ -33,8 +33,8 @@
  
          *)
@@ -28,7 +28,7 @@ diff -urN nginx-1.25.3.orig/auto/lib/zlib/conf nginx-1.25.3/auto/lib/zlib/conf
  
 diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_gunzip_filter_module.c nginx-1.25.3/src/http/modules/ngx_http_gunzip_filter_module.c
 --- nginx-1.25.3.orig/src/http/modules/ngx_http_gunzip_filter_module.c	2023-10-24 15:46:47.000000000 +0200
-+++ nginx-1.25.3/src/http/modules/ngx_http_gunzip_filter_module.c	2023-11-25 04:00:16.017729654 +0100
++++ nginx-1.25.3/src/http/modules/ngx_http_gunzip_filter_module.c	2023-11-25 16:50:20.103591053 +0100
 @@ -10,7 +10,14 @@
  #include <ngx_core.h>
  #include <ngx_http.h>
@@ -83,7 +83,7 @@ diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_gunzip_filter_module.c ngi
          ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
 diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_gzip_filter_module.c nginx-1.25.3/src/http/modules/ngx_http_gzip_filter_module.c
 --- nginx-1.25.3.orig/src/http/modules/ngx_http_gzip_filter_module.c	2023-10-24 15:46:47.000000000 +0200
-+++ nginx-1.25.3/src/http/modules/ngx_http_gzip_filter_module.c	2023-11-25 04:01:03.754887799 +0100
++++ nginx-1.25.3/src/http/modules/ngx_http_gzip_filter_module.c	2023-11-25 16:50:20.103591053 +0100
 @@ -9,7 +9,14 @@
  #include <ngx_core.h>
  #include <ngx_http.h>
@@ -100,26 +100,7 @@ diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_gzip_filter_module.c nginx
  
  
  typedef struct {
-@@ -56,8 +63,7 @@
-     unsigned             done:1;
-     unsigned             nomem:1;
-     unsigned             buffering:1;
--    unsigned             zlib_ng:1;
--    unsigned             state_allocated:1;
-+    unsigned             intel:1;
- 
-     size_t               zin;
-     size_t               zout;
-@@ -214,7 +220,7 @@
- static ngx_http_output_header_filter_pt  ngx_http_next_header_filter;
- static ngx_http_output_body_filter_pt    ngx_http_next_body_filter;
- 
--static ngx_uint_t  ngx_http_gzip_assume_zlib_ng;
-+static ngx_uint_t  ngx_http_gzip_assume_intel;
- 
- 
- static ngx_int_t
-@@ -454,7 +460,7 @@
+@@ -454,7 +461,7 @@
      ctx->done = 1;
  
      if (ctx->preallocated) {
@@ -128,55 +109,7 @@ diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_gzip_filter_module.c nginx
  
          ngx_pfree(r->pool, ctx->preallocated);
      }
-@@ -503,32 +509,32 @@
-      * 8K is for zlib deflate_state, it takes
-      *  *) 5816 bytes on i386 and sparc64 (32-bit mode)
-      *  *) 5920 bytes on amd64 and sparc64
--     *
--     * A zlib variant from Intel (https://github.com/jtkukunas/zlib)
--     * uses additional 16-byte padding in one of window-sized buffers.
-      */
- 
--    if (!ngx_http_gzip_assume_zlib_ng) {
--        ctx->allocated = 8192 + 16 + (1 << (wbits + 2))
--                         + (1 << (memlevel + 9));
-+    if (!ngx_http_gzip_assume_intel) {
-+        ctx->allocated = 8192 + (1 << (wbits + 2)) + (1 << (memlevel + 9));
- 
-     } else {
-         /*
--         * Another zlib variant, https://github.com/zlib-ng/zlib-ng.
--         * It used to force window bits to 13 for fast compression level,
--         * uses (64 + sizeof(void*)) additional space on all allocations
--         * for alignment, 16-byte padding in one of window-sized buffers,
--         * and 128K hash.
-+         * A zlib variant from Intel, https://github.com/jtkukunas/zlib.
-+         * It can force window bits to 13 for fast compression level,
-+         * on processors with SSE 4.2 it uses 64K hash instead of scaling
-+         * it from the specified memory level, and also introduces
-+         * 16-byte padding in one out of the two window-sized buffers.
-          */
- 
-         if (conf->level == 1) {
-             wbits = ngx_max(wbits, 13);
-         }
- 
--        ctx->allocated = 8192 + 16 + (1 << (wbits + 2))
--                         + 131072 + (1 << (memlevel + 8))
--                         + 4 * (64 + sizeof(void*));
--        ctx->zlib_ng = 1;
-+        // zlib-ng
-+        ctx->allocated = 8192                                /* deflate_state + padding + extra? */
-+                         + (1 << (wbits + 1)) + 8            /* s->window + s->prev + padding */
-+                         + (1 << (17)) + 8                   /* s->head */
-+                         + (1 << (ngx_max(memlevel, 8) + 8)) /* s->pending_buf */
-+                         + (1 << (memlevel + 8));            /* not sure */
-+
-+        ctx->intel = 1;
-     }
- }
- 
-@@ -621,7 +627,7 @@
+@@ -621,7 +628,7 @@
      ctx->zstream.zfree = ngx_http_gzip_filter_free;
      ctx->zstream.opaque = ctx;
  
@@ -185,7 +118,7 @@ diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_gzip_filter_module.c nginx
                        ctx->wbits + 16, ctx->memlevel, Z_DEFAULT_STRATEGY);
  
      if (rc != Z_OK) {
-@@ -756,7 +762,7 @@
+@@ -756,7 +763,7 @@
                   ctx->zstream.avail_in, ctx->zstream.avail_out,
                   ctx->flush, ctx->redo);
  
@@ -194,7 +127,7 @@ diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_gzip_filter_module.c nginx
  
      if (rc != Z_OK && rc != Z_STREAM_END && rc != Z_BUF_ERROR) {
          ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-@@ -880,7 +886,7 @@
+@@ -880,7 +887,7 @@
      ctx->zin = ctx->zstream.total_in;
      ctx->zout = ctx->zstream.total_out;
  
@@ -203,44 +136,9 @@ diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_gzip_filter_module.c nginx
  
      if (rc != Z_OK) {
          ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-@@ -929,16 +935,13 @@
- 
-     alloc = items * size;
- 
--    if (items == 1 && alloc % 512 != 0 && alloc < 8192
--        && !ctx->state_allocated)
--    {
-+    if (items == 1 && alloc % 512 != 0 && alloc < 8192) {
-+
-         /*
-          * The zlib deflate_state allocation, it takes about 6K,
-          * we allocate 8K.  Other allocations are divisible by 512.
-          */
- 
--        ctx->state_allocated = 1;
--
-         alloc = 8192;
-     }
- 
-@@ -954,13 +957,13 @@
-         return p;
-     }
- 
--    if (ctx->zlib_ng) {
-+    if (ctx->intel) {
-         ngx_log_error(NGX_LOG_ALERT, ctx->request->connection->log, 0,
-                       "gzip filter failed to use preallocated memory: "
-                       "%ud of %ui", items * size, ctx->allocated);
- 
-     } else {
--        ngx_http_gzip_assume_zlib_ng = 1;
-+        ngx_http_gzip_assume_intel = 1;
-     }
- 
-     p = ngx_palloc(ctx->request->pool, items * size);
 diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_log_module.c nginx-1.25.3/src/http/modules/ngx_http_log_module.c
 --- nginx-1.25.3.orig/src/http/modules/ngx_http_log_module.c	2023-10-24 15:46:47.000000000 +0200
-+++ nginx-1.25.3/src/http/modules/ngx_http_log_module.c	2023-11-25 04:00:16.021729227 +0100
++++ nginx-1.25.3/src/http/modules/ngx_http_log_module.c	2023-11-25 16:50:20.103591053 +0100
 @@ -9,8 +9,13 @@
  #include <ngx_core.h>
  #include <ngx_http.h>
@@ -286,7 +184,7 @@ diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_log_module.c nginx-1.25.3/
          ngx_log_error(NGX_LOG_ALERT, log, 0, "deflateEnd() failed: %d", rc);
 diff -urN nginx-1.25.3.orig/src/stream/ngx_stream_log_module.c nginx-1.25.3/src/stream/ngx_stream_log_module.c
 --- nginx-1.25.3.orig/src/stream/ngx_stream_log_module.c	2023-10-24 15:46:47.000000000 +0200
-+++ nginx-1.25.3/src/stream/ngx_stream_log_module.c	2023-11-25 15:33:19.553991166 +0100
++++ nginx-1.25.3/src/stream/ngx_stream_log_module.c	2023-11-25 16:50:20.103591053 +0100
 @@ -9,8 +9,13 @@
  #include <ngx_core.h>
  #include <ngx_stream.h>

--- a/nginx/1.25.3-zlib-ng.patch
+++ b/nginx/1.25.3-zlib-ng.patch
@@ -1,0 +1,341 @@
+diff -urN nginx-1.25.3.orig/auto/lib/zlib/conf nginx-1.25.3/auto/lib/zlib/conf
+--- nginx-1.25.3.orig/auto/lib/zlib/conf	2023-10-24 15:46:47.000000000 +0200
++++ nginx-1.25.3/auto/lib/zlib/conf	2023-11-25 04:00:16.017729654 +0100
+@@ -33,8 +33,8 @@
+ 
+         *)
+             have=NGX_ZLIB . auto/have
+-            LINK_DEPS="$LINK_DEPS $ZLIB/libz.a"
+-            CORE_LIBS="$CORE_LIBS $ZLIB/libz.a"
++            LINK_DEPS="$LINK_DEPS $ZLIB/libz-ng.a"
++            CORE_LIBS="$CORE_LIBS $ZLIB/libz-ng.a"
+             #CORE_LIBS="$CORE_LIBS -L $ZLIB -lz"
+         ;;
+ 
+@@ -50,10 +50,10 @@
+         ngx_feature="zlib library"
+         ngx_feature_name="NGX_ZLIB"
+         ngx_feature_run=no
+-        ngx_feature_incs="#include <zlib.h>"
++        ngx_feature_incs="#include <zlib-ng.h>"
+         ngx_feature_path=
+-        ngx_feature_libs="-lz"
+-        ngx_feature_test="z_stream z; deflate(&z, Z_NO_FLUSH)"
++        ngx_feature_libs="-lz-ng"
++        ngx_feature_test="zng_stream z; zng_deflate(&z, Z_NO_FLUSH)"
+         . auto/feature
+ 
+ 
+diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_gunzip_filter_module.c nginx-1.25.3/src/http/modules/ngx_http_gunzip_filter_module.c
+--- nginx-1.25.3.orig/src/http/modules/ngx_http_gunzip_filter_module.c	2023-10-24 15:46:47.000000000 +0200
++++ nginx-1.25.3/src/http/modules/ngx_http_gunzip_filter_module.c	2023-11-25 04:00:16.017729654 +0100
+@@ -10,7 +10,14 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ 
+-#include <zlib.h>
++#if defined(NGX_ZLIB_NG)
++# include <zlib-ng.h>
++# define ZPREFIX(x) zng_ ## x
++# define z_stream zng_stream
++#elif defined(NGX_ZLIB)
++# include <zlib.h>
++# define ZPREFIX(x) x
++#endif
+ 
+ 
+ typedef struct {
+@@ -312,7 +319,7 @@
+     ctx->zstream.opaque = ctx;
+ 
+     /* windowBits +16 to decode gzip, zlib 1.2.0.4+ */
+-    rc = inflateInit2(&ctx->zstream, MAX_WBITS + 16);
++    rc = ZPREFIX(inflateInit2)(&ctx->zstream, MAX_WBITS + 16);
+ 
+     if (rc != Z_OK) {
+         ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+@@ -425,7 +432,7 @@
+                    ctx->zstream.avail_in, ctx->zstream.avail_out,
+                    ctx->flush, ctx->redo);
+ 
+-    rc = inflate(&ctx->zstream, ctx->flush);
++    rc = ZPREFIX(inflate)(&ctx->zstream, ctx->flush);
+ 
+     if (rc != Z_OK && rc != Z_STREAM_END && rc != Z_BUF_ERROR) {
+         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+@@ -523,7 +530,7 @@
+ 
+     if (rc == Z_STREAM_END && ctx->zstream.avail_in > 0) {
+ 
+-        rc = inflateReset(&ctx->zstream);
++        rc = ZPREFIX(inflateReset)(&ctx->zstream);
+ 
+         if (rc != Z_OK) {
+             ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+@@ -574,7 +581,7 @@
+     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                    "gunzip inflate end");
+ 
+-    rc = inflateEnd(&ctx->zstream);
++    rc = ZPREFIX(inflateEnd)(&ctx->zstream);
+ 
+     if (rc != Z_OK) {
+         ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_gzip_filter_module.c nginx-1.25.3/src/http/modules/ngx_http_gzip_filter_module.c
+--- nginx-1.25.3.orig/src/http/modules/ngx_http_gzip_filter_module.c	2023-10-24 15:46:47.000000000 +0200
++++ nginx-1.25.3/src/http/modules/ngx_http_gzip_filter_module.c	2023-11-25 04:01:03.754887799 +0100
+@@ -9,7 +9,14 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ 
+-#include <zlib.h>
++#if defined(NGX_ZLIB_NG)
++# include <zlib-ng.h>
++# define ZPREFIX(x) zng_ ## x
++# define z_stream zng_stream
++#elif defined(NGX_ZLIB)
++# include <zlib.h>
++# define ZPREFIX(x) x
++#endif
+ 
+ 
+ typedef struct {
+@@ -56,8 +63,7 @@
+     unsigned             done:1;
+     unsigned             nomem:1;
+     unsigned             buffering:1;
+-    unsigned             zlib_ng:1;
+-    unsigned             state_allocated:1;
++    unsigned             intel:1;
+ 
+     size_t               zin;
+     size_t               zout;
+@@ -214,7 +220,7 @@
+ static ngx_http_output_header_filter_pt  ngx_http_next_header_filter;
+ static ngx_http_output_body_filter_pt    ngx_http_next_body_filter;
+ 
+-static ngx_uint_t  ngx_http_gzip_assume_zlib_ng;
++static ngx_uint_t  ngx_http_gzip_assume_intel;
+ 
+ 
+ static ngx_int_t
+@@ -454,7 +460,7 @@
+     ctx->done = 1;
+ 
+     if (ctx->preallocated) {
+-        deflateEnd(&ctx->zstream);
++        ZPREFIX(deflateEnd)(&ctx->zstream);
+ 
+         ngx_pfree(r->pool, ctx->preallocated);
+     }
+@@ -503,32 +509,32 @@
+      * 8K is for zlib deflate_state, it takes
+      *  *) 5816 bytes on i386 and sparc64 (32-bit mode)
+      *  *) 5920 bytes on amd64 and sparc64
+-     *
+-     * A zlib variant from Intel (https://github.com/jtkukunas/zlib)
+-     * uses additional 16-byte padding in one of window-sized buffers.
+      */
+ 
+-    if (!ngx_http_gzip_assume_zlib_ng) {
+-        ctx->allocated = 8192 + 16 + (1 << (wbits + 2))
+-                         + (1 << (memlevel + 9));
++    if (!ngx_http_gzip_assume_intel) {
++        ctx->allocated = 8192 + (1 << (wbits + 2)) + (1 << (memlevel + 9));
+ 
+     } else {
+         /*
+-         * Another zlib variant, https://github.com/zlib-ng/zlib-ng.
+-         * It used to force window bits to 13 for fast compression level,
+-         * uses (64 + sizeof(void*)) additional space on all allocations
+-         * for alignment, 16-byte padding in one of window-sized buffers,
+-         * and 128K hash.
++         * A zlib variant from Intel, https://github.com/jtkukunas/zlib.
++         * It can force window bits to 13 for fast compression level,
++         * on processors with SSE 4.2 it uses 64K hash instead of scaling
++         * it from the specified memory level, and also introduces
++         * 16-byte padding in one out of the two window-sized buffers.
+          */
+ 
+         if (conf->level == 1) {
+             wbits = ngx_max(wbits, 13);
+         }
+ 
+-        ctx->allocated = 8192 + 16 + (1 << (wbits + 2))
+-                         + 131072 + (1 << (memlevel + 8))
+-                         + 4 * (64 + sizeof(void*));
+-        ctx->zlib_ng = 1;
++        // zlib-ng
++        ctx->allocated = 8192                                /* deflate_state + padding + extra? */
++                         + (1 << (wbits + 1)) + 8            /* s->window + s->prev + padding */
++                         + (1 << (17)) + 8                   /* s->head */
++                         + (1 << (ngx_max(memlevel, 8) + 8)) /* s->pending_buf */
++                         + (1 << (memlevel + 8));            /* not sure */
++
++        ctx->intel = 1;
+     }
+ }
+ 
+@@ -621,7 +627,7 @@
+     ctx->zstream.zfree = ngx_http_gzip_filter_free;
+     ctx->zstream.opaque = ctx;
+ 
+-    rc = deflateInit2(&ctx->zstream, (int) conf->level, Z_DEFLATED,
++    rc = ZPREFIX(deflateInit2)(&ctx->zstream, (int) conf->level, Z_DEFLATED,
+                       ctx->wbits + 16, ctx->memlevel, Z_DEFAULT_STRATEGY);
+ 
+     if (rc != Z_OK) {
+@@ -756,7 +762,7 @@
+                  ctx->zstream.avail_in, ctx->zstream.avail_out,
+                  ctx->flush, ctx->redo);
+ 
+-    rc = deflate(&ctx->zstream, ctx->flush);
++    rc = ZPREFIX(deflate)(&ctx->zstream, ctx->flush);
+ 
+     if (rc != Z_OK && rc != Z_STREAM_END && rc != Z_BUF_ERROR) {
+         ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+@@ -880,7 +886,7 @@
+     ctx->zin = ctx->zstream.total_in;
+     ctx->zout = ctx->zstream.total_out;
+ 
+-    rc = deflateEnd(&ctx->zstream);
++    rc = ZPREFIX(deflateEnd)(&ctx->zstream);
+ 
+     if (rc != Z_OK) {
+         ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+@@ -929,16 +935,13 @@
+ 
+     alloc = items * size;
+ 
+-    if (items == 1 && alloc % 512 != 0 && alloc < 8192
+-        && !ctx->state_allocated)
+-    {
++    if (items == 1 && alloc % 512 != 0 && alloc < 8192) {
++
+         /*
+          * The zlib deflate_state allocation, it takes about 6K,
+          * we allocate 8K.  Other allocations are divisible by 512.
+          */
+ 
+-        ctx->state_allocated = 1;
+-
+         alloc = 8192;
+     }
+ 
+@@ -954,13 +957,13 @@
+         return p;
+     }
+ 
+-    if (ctx->zlib_ng) {
++    if (ctx->intel) {
+         ngx_log_error(NGX_LOG_ALERT, ctx->request->connection->log, 0,
+                       "gzip filter failed to use preallocated memory: "
+                       "%ud of %ui", items * size, ctx->allocated);
+ 
+     } else {
+-        ngx_http_gzip_assume_zlib_ng = 1;
++        ngx_http_gzip_assume_intel = 1;
+     }
+ 
+     p = ngx_palloc(ctx->request->pool, items * size);
+diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_log_module.c nginx-1.25.3/src/http/modules/ngx_http_log_module.c
+--- nginx-1.25.3.orig/src/http/modules/ngx_http_log_module.c	2023-10-24 15:46:47.000000000 +0200
++++ nginx-1.25.3/src/http/modules/ngx_http_log_module.c	2023-11-25 04:00:16.021729227 +0100
+@@ -9,8 +9,13 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ 
+-#if (NGX_ZLIB)
+-#include <zlib.h>
++#if defined(NGX_ZLIB_NG)
++# include <zlib-ng.h>
++# define ZPREFIX(x) zng_ ## x
++# define z_stream zng_stream
++#elif defined(NGX_ZLIB)
++# include <zlib.h>
++# define ZPREFIX(x) x
+ #endif
+ 
+ 
+@@ -634,7 +639,7 @@
+     zstream.next_out = out;
+     zstream.avail_out = size;
+ 
+-    rc = deflateInit2(&zstream, (int) level, Z_DEFLATED, wbits + 16, memlevel,
++    rc = ZPREFIX(deflateInit2)(&zstream, (int) level, Z_DEFLATED, wbits + 16, memlevel,
+                       Z_DEFAULT_STRATEGY);
+ 
+     if (rc != Z_OK) {
+@@ -647,7 +652,7 @@
+                    zstream.next_in, zstream.next_out,
+                    zstream.avail_in, zstream.avail_out);
+ 
+-    rc = deflate(&zstream, Z_FINISH);
++    rc = ZPREFIX(deflate)(&zstream, Z_FINISH);
+ 
+     if (rc != Z_STREAM_END) {
+         ngx_log_error(NGX_LOG_ALERT, log, 0,
+@@ -663,7 +668,7 @@
+ 
+     size -= zstream.avail_out;
+ 
+-    rc = deflateEnd(&zstream);
++    rc = ZPREFIX(deflateEnd)(&zstream);
+ 
+     if (rc != Z_OK) {
+         ngx_log_error(NGX_LOG_ALERT, log, 0, "deflateEnd() failed: %d", rc);
+diff -urN nginx-1.25.3.orig/src/stream/ngx_stream_log_module.c nginx-1.25.3/src/stream/ngx_stream_log_module.c
+--- nginx-1.25.3.orig/src/stream/ngx_stream_log_module.c	2023-10-24 15:46:47.000000000 +0200
++++ nginx-1.25.3/src/stream/ngx_stream_log_module.c	2023-11-25 04:00:16.021729227 +0100
+@@ -9,8 +9,13 @@
+ #include <ngx_core.h>
+ #include <ngx_stream.h>
+ 
+-#if (NGX_ZLIB)
+-#include <zlib.h>
++#if defined(NGX_ZLIB_NG)
++# include <zlib-ng.h>
++# define ZPREFIX(x) zng_ ## x
++# define z_stream zng_stream
++#elif defined(NGX_ZLIB)
++# include <zlib.h>
++# define ZPREFIX(x) x
+ #endif
+ 
+ 
+@@ -482,7 +487,7 @@
+     u_char      *out;
+     size_t       size;
+     ssize_t      n;
+-    z_stream     zstream;
++    z_stream   zstream;
+     ngx_err_t    err;
+     ngx_pool_t  *pool;
+ 
+@@ -525,7 +530,7 @@
+     zstream.next_out = out;
+     zstream.avail_out = size;
+ 
+-    rc = deflateInit2(&zstream, (int) level, Z_DEFLATED, wbits + 16, memlevel,
++    rc = ZPREFIX(deflateInit2)(&zstream, (int) level, Z_DEFLATED, wbits + 16, memlevel,
+                       Z_DEFAULT_STRATEGY);
+ 
+     if (rc != Z_OK) {
+@@ -538,7 +543,7 @@
+                    zstream.next_in, zstream.next_out,
+                    zstream.avail_in, zstream.avail_out);
+ 
+-    rc = deflate(&zstream, Z_FINISH);
++    rc = ZPREFIX(deflate)(&zstream, Z_FINISH);
+ 
+     if (rc != Z_STREAM_END) {
+         ngx_log_error(NGX_LOG_ALERT, log, 0,
+@@ -554,7 +559,7 @@
+ 
+     size -= zstream.avail_out;
+ 
+-    rc = deflateEnd(&zstream);
++    rc = ZPREFIX(deflateEnd)(&zstream);
+ 
+     if (rc != Z_OK) {
+         ngx_log_error(NGX_LOG_ALERT, log, 0, "deflateEnd() failed: %d", rc);

--- a/nginx/1.25.3-zlib-ng.patch
+++ b/nginx/1.25.3-zlib-ng.patch
@@ -286,7 +286,7 @@ diff -urN nginx-1.25.3.orig/src/http/modules/ngx_http_log_module.c nginx-1.25.3/
          ngx_log_error(NGX_LOG_ALERT, log, 0, "deflateEnd() failed: %d", rc);
 diff -urN nginx-1.25.3.orig/src/stream/ngx_stream_log_module.c nginx-1.25.3/src/stream/ngx_stream_log_module.c
 --- nginx-1.25.3.orig/src/stream/ngx_stream_log_module.c	2023-10-24 15:46:47.000000000 +0200
-+++ nginx-1.25.3/src/stream/ngx_stream_log_module.c	2023-11-25 04:00:16.021729227 +0100
++++ nginx-1.25.3/src/stream/ngx_stream_log_module.c	2023-11-25 15:33:19.553991166 +0100
 @@ -9,8 +9,13 @@
  #include <ngx_core.h>
  #include <ngx_stream.h>
@@ -302,15 +302,6 @@ diff -urN nginx-1.25.3.orig/src/stream/ngx_stream_log_module.c nginx-1.25.3/src/
 +# define ZPREFIX(x) x
  #endif
  
- 
-@@ -482,7 +487,7 @@
-     u_char      *out;
-     size_t       size;
-     ssize_t      n;
--    z_stream     zstream;
-+    z_stream   zstream;
-     ngx_err_t    err;
-     ngx_pool_t  *pool;
  
 @@ -525,7 +530,7 @@
      zstream.next_out = out;

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -3,3 +3,10 @@
 * Link to native zlib-ng instead of zlib
 * Prefix all zlib calls
 * Increase the size of pre-allocated memory to fit with zlib-ng requirements
+
+## 1.25.3-zlib-ng.patch
+* Patch created against Nginx 1.25.3
+* Link to native zlib-ng instead of zlib
+* Prefix all zlib calls
+* Increase the size of pre-allocated memory to fit with zlib-ng requirements
+


### PR DESCRIPTION
Rebased the patch for nginx 1.25.3 by reverting all "zlib-ng in compat mode" changes the nginx team has made, allowing to apply the 1.18 patch

Live in action on https://deb.myguard.nl/nginx-modules